### PR TITLE
Update README.md after upgrade to Next.js 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img alt="Shows all of the tools in the stack for this template, also listed in the README file." src="https://user-images.githubusercontent.com/9113740/201498152-b171abb8-9225-487a-821c-6ff49ee48579.png">
 </picture>
 
-<div align="center"><strong>Next.js 13 Admin Dashboard Template</strong></div>
+<div align="center"><strong>Next.js 14 Admin Dashboard Template</strong></div>
 <div align="center">Built with the Next.js App Router</div>
 <br />
 <div align="center">
@@ -18,7 +18,7 @@
 
 This is a starter template using the following stack:
 
-- Framework - [Next.js 13](https://nextjs.org/13)
+- Framework - [Next.js 14](https://nextjs.org/14)
 - Language - [TypeScript](https://www.typescriptlang.org)
 - Auth - [NextAuth.js](https://next-auth.js.org)
 - Database - [Vercel Postgres](https://vercel.com/postgres)


### PR DESCRIPTION
The template was updated to Next.js 14 in https://github.com/vercel/nextjs-postgres-nextauth-tailwindcss-template/pull/26. Update the README to reflect these changes