### PR TITLE
Update Auth.js name and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a starter template using the following stack:
 
 - Framework - [Next.js 14](https://nextjs.org/)
 - Language - [TypeScript](https://www.typescriptlang.org)
-- Auth - [NextAuth.js](https://next-auth.js.org)
+- Auth - [Auth.js](https://authjs.dev)
 - Database - [Postgres](https://vercel.com/postgres)
 - Deployment - [Vercel](https://vercel.com/docs/concepts/next.js/overview)
 - Styling - [Tailwind CSS](https://tailwindcss.com)


### PR DESCRIPTION
Since the package.json uses `next-auth@5.0.0-beta`, the readme should link to the new documentation along with the updated name.