### PR TITLE
styling body with 'w-full' causes a layout shift when opening a dialog (disabling the scroll)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className="flex min-h-screen w-full flex-col">{children}</body>
+      <body className="flex min-h-screen flex-col">{children}</body>
       <Analytics />
     </html>
   );


### PR DESCRIPTION
You can open the user menu to see the issue in the [demo](https://next-admin-dash.vercel.app/).