### PR TITLE
Avoid negative value when no products

### DIFF
--- a/app/(dashboard)/products-table.tsx
+++ b/app/(dashboard)/products-table.tsx
@@ -80,7 +80,7 @@ export function ProductsTable({
           <div className="text-xs text-muted-foreground">
             Showing{' '}
             <strong>
-              {Math.min(offset - productsPerPage, totalProducts) + 1}-{offset}
+              {Math.max(0, Math.min(offset - productsPerPage, totalProducts) + 1)}-{offset}
             </strong>{' '}
             of <strong>{totalProducts}</strong> products
           </div>


### PR DESCRIPTION
If there are no products, the footer message renders "Showing -4 - 0 of 0 products" which is weird. Make sure to instead render "Showing 0-0 of 0 products"