### PR TITLE
Fix incorrect navigation routes in MobileNav component

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -141,14 +141,14 @@ function MobileNav() {
             Orders
           </Link>
           <Link
-            href="#"
+            href="/"
             className="flex items-center gap-4 px-2.5 text-foreground"
           >
             <Package className="h-5 w-5" />
             Products
           </Link>
           <Link
-            href="#"
+            href="/customers"
             className="flex items-center gap-4 px-2.5 text-muted-foreground hover:text-foreground"
           >
             <Users2 className="h-5 w-5" />


### PR DESCRIPTION
Fixed two incorrect navigation routes in the MobileNav component:

- Updated Products link to navigate to "/" instead of "#"

- Updated Customers link to navigate to "/customers" instead of "#"

These changes align the mobile navigation with the intended routing behavior and improve user experience.

### Checklist

- [x] Navigation to Products (/) works as expected

- [x] Navigation to Customers (/customers) works as expected

- [x] No other navigation routes were affected

- [x] Mobile menu functionality remains intact

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)