### PR TITLE
Add language identifiers to code blocks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ During the deployment, Vercel will prompt you to create a new Postgres database.
 
 Inside the Vercel Postgres dashboard, create a table based on the schema defined in this repository.
 
-```
+```sql
 CREATE TYPE status AS ENUM ('active', 'inactive', 'archived');
 
 CREATE TABLE products (
@@ -56,7 +56,7 @@ vercel env pull
 
 Finally, run the following commands to start the development server:
 
-```
+```bash
 pnpm install
 pnpm dev
 ```


### PR DESCRIPTION
## Summary
- Add `sql` language identifier to the database schema code block
- Add `bash` language identifier to the pnpm commands code block

This enables proper syntax highlighting when the README is rendered on vercel.com/templates.